### PR TITLE
Ignore background self messages

### DIFF
--- a/background.js
+++ b/background.js
@@ -15,6 +15,11 @@ let currentOperationContext = {
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log("Background received message:", message.action, message); // Log action and message
 
+    // Ignore messages originating from the background script itself
+    if (sender.id === chrome.runtime.id) {
+        return false;
+    }
+
     if (message.action === "setBaseConfigContext") {
         // Store the base config string provided by the popup for the upcoming player processing
         console.log("Setting base config context");
@@ -88,6 +93,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
          currentOperationContext.baseConfig = null;
          sendResponse({ status: "Extraction error forwarded"});
          return false;
+    } else if (message.action === "updateStatus" || message.action === "downloadFile" || message.action === "displayError") {
+        // These messages are intended for the popup; background doesn't need to handle them
+        return false;
     }
 
     // Handle other potential messages if needed


### PR DESCRIPTION
## Summary
- ignore onMessage events sent by the extension's own background script
- ignore updateStatus, downloadFile and displayError actions to prevent unnecessary "Unknown message" logs

## Testing
- `node --check background.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68912ce01130832e8db8a6c7d708494a