### PR TITLE
Remove unused default config

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,11 +1,5 @@
 // --- Background Service Worker (background.js) ---
 
-// Default base config (used only if custom retrieval fails unexpectedly)
-const defaultBaseStreamfinderConfig = {
-    "on_deck": "Y", "include_CLI": "N", "delay": "10000", "ignore": ["108"],
-    "priority": [ {"type": "NoNo", "data": "7", "immediate": "", "priority": 1} ] // Example minimal default
-};
-
 // Variable to hold the base config for the current operation
 let currentOperationContext = {
     baseConfig: null


### PR DESCRIPTION
## Summary
- remove unused `defaultBaseStreamfinderConfig` declaration from background service worker

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run build` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68912ce2ef24832e931688d151928da6