### PR TITLE
chore: run CI once for PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- avoid duplicate CI runs by restricting pushes to main

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689142dc238c832ea75268fc1e95da3d