### PR TITLE
Fix Playwright test waiting for extension service worker

### DIFF
--- a/tests/e2e.playwright.js
+++ b/tests/e2e.playwright.js
@@ -12,8 +12,8 @@ test('generate config and upload to stream finder', async () => {
     ]
   });
 
-  const background = await context.waitForEvent('backgroundpage');
-  const extensionId = background.url().split('/')[2];
+  const serviceWorker = await context.waitForEvent('serviceworker');
+  const extensionId = serviceWorker.url().split('/')[2];
 
   const ottoneuPage = await context.newPage();
   await ottoneuPage.goto('https://ottoneu.fangraphs.com/sixpicks/view/74779');


### PR DESCRIPTION
## Summary
- fix Playwright E2E test by waiting for MV3 service worker to grab extension ID

## Testing
- `npm test`
- `npx playwright test tests/e2e.playwright.js` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689244ea1030832ebd47c2907c91247b