### PR TITLE
fix e2e test

### DIFF
--- a/tests/e2e.playwright.js
+++ b/tests/e2e.playwright.js
@@ -6,28 +6,57 @@ test('generate config and upload to stream finder', async () => {
   const extensionPath = path.join(__dirname, '..');
   const context = await chromium.launchPersistentContext('', {
     headless: false,
+    ignoreHTTPSErrors: true,
+    ignoreDefaultArgs: ['--disable-background-networking'],
     args: [
       `--disable-extensions-except=${extensionPath}`,
       `--load-extension=${extensionPath}`
     ]
   });
 
-  const serviceWorker = await context.waitForEvent('serviceworker');
+  // Stub MLB Stats API responses so tests do not rely on external network.
+  let mockId = 1;
+  await context.route('https://statsapi.mlb.com/*', route => {
+    const body = JSON.stringify({ people: [{ id: mockId++ }] });
+    route.fulfill({ contentType: 'application/json', body });
+  });
+
+  // Extension service worker may already be running by the time this test
+  // starts listening for it. Check for an existing worker first so we don't
+  // hang waiting for a second one that will never appear.
+  let [serviceWorker] = context.serviceWorkers();
+  if (!serviceWorker) {
+    serviceWorker = await context.waitForEvent('serviceworker');
+  }
   const extensionId = serviceWorker.url().split('/')[2];
+  console.log('Loaded extension with id', extensionId);
+  serviceWorker.on('console', msg => console.log('sw console:', msg.text()));
 
   const ottoneuPage = await context.newPage();
+  console.log('Navigating to Ottoneu six picks page');
   await ottoneuPage.goto('https://ottoneu.fangraphs.com/sixpicks/view/74779');
+  console.log('Ottoneu page loaded');
 
   const baseConfigPath = path.join(__dirname, 'baseConfig.json');
   fs.writeFileSync(baseConfigPath, JSON.stringify({ priority: [] }));
 
-  const popup = await context.newPage();
-  await popup.goto(`chrome-extension://${extensionId}/popup.html`);
+  console.log('Opening extension popup');
+  const [popup] = await Promise.all([
+    context.waitForEvent('page'),
+    serviceWorker.evaluate(id => chrome.tabs.create({ url: `chrome-extension://${id}/popup.html`, active: false }), extensionId)
+  ]);
+  console.log('Popup loaded');
+  popup.on('console', msg => console.log('popup console:', msg.text()));
 
+  console.log('Uploading base config');
   await popup.setInputFiles('#configFile', baseConfigPath);
   await popup.click('#saveConfigButton');
+  await popup.waitForSelector('#configStatus.success');
+  console.log('Base config saved');
 
   await ottoneuPage.bringToFront();
+  console.log('Generating stream finder config');
+  console.log('Triggering generate button');
 
   const [download] = await Promise.all([
     popup.waitForEvent('download'),
@@ -42,8 +71,10 @@ test('generate config and upload to stream finder', async () => {
   expect(config.priority.length).toBeGreaterThan(0);
 
   await ottoneuPage.goto('https://www.baseball-reference.com/stream-finder.shtml');
+  console.log('Navigated to stream finder upload page');
   const fileInput = await ottoneuPage.$('input[type=file]');
   await fileInput.setInputFiles(downloadPath);
+  console.log('Uploaded generated config');
 
   await context.close();
 });


### PR DESCRIPTION
## Summary
- restore original manifest, popup, and background scripts after previous permission changes
- revert background unit tests to match original behavior
- adjust Playwright test to launch the popup in a background tab while mocking MLB API calls

## Testing
- `npm test`
- `xvfb-run -a npm run test:e2e` *(fails: Error: Not on an Ottoneu Six Picks view or createEntry page)*

------
https://chatgpt.com/codex/tasks/task_e_6892487710e0832eb826b2276170a454