### PR TITLE
Add GitHub Action for E2E tests

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -1,0 +1,19 @@
+name: Run e2e tests
+description: Install dependencies and run Playwright end-to-end tests
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: npm
+    - name: Install dependencies
+      run: npm ci
+      shell: bash
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps
+      shell: bash
+    - name: Run e2e tests
+      run: xvfb-run -a npm run test:e2e
+      shell: bash

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,13 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/run-e2e-tests


### PR DESCRIPTION
## Summary
- add composite action to install dependencies and run Playwright e2e tests
- run e2e test workflow after merges to `main`

## Testing
- `npm test`
- `xvfb-run -a npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68926d5cef3c832eb798d84e51adb55e