### PR TITLE
Attach Playwright video artifact to e2e workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,3 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/run-e2e-tests
+      - name: Upload Playwright video
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-video
+          path: playwright-artifacts
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules/
 coverage/
+playwright-artifacts/
+test-results/

--- a/tests/e2e.playwright.js
+++ b/tests/e2e.playwright.js
@@ -4,6 +4,9 @@ const fs = require('fs');
 
 test('generate config and upload to stream finder', async () => {
   const extensionPath = path.join(__dirname, '..');
+  const videoDir = path.join(__dirname, '..', 'playwright-artifacts');
+  fs.mkdirSync(videoDir, { recursive: true });
+
   const context = await chromium.launchPersistentContext('', {
     headless: false,
     ignoreHTTPSErrors: true,
@@ -11,7 +14,8 @@ test('generate config and upload to stream finder', async () => {
     args: [
       `--disable-extensions-except=${extensionPath}`,
       `--load-extension=${extensionPath}`
-    ]
+    ],
+    recordVideo: { dir: videoDir }
   });
 
   // Stub MLB Stats API fetch in the service worker so tests do not rely on external network.


### PR DESCRIPTION
## Summary
- record Playwright videos during e2e test runs
- upload recorded videos as GitHub Action artifacts
- ignore generated artifact directories

## Testing
- `npm test`
- `xvfb-run -a npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689290e4c930832e822c4f52249fad2b